### PR TITLE
FIX: open new empty window, similar to "open new tab"

### DIFF
--- a/service-worker-scripts/operations/open-new-window-operation.js
+++ b/service-worker-scripts/operations/open-new-window-operation.js
@@ -1,11 +1,5 @@
 export class OpenNewWindowOperation {
   async doAsync() {
-    const currentTab = await chrome.tabs.query({ active: true, currentWindow: true });
-    let url = '';
-    if (currentTab?.length > 0 && currentTab[0].url) {
-      url = currentTab[0].url;
-    }
-
-    chrome.windows.create({ url, state: 'maximized' });
+    chrome.windows.create();
   }
 }

--- a/service-worker-scripts/operations/open-new-window-operation.js
+++ b/service-worker-scripts/operations/open-new-window-operation.js
@@ -1,5 +1,6 @@
 export class OpenNewWindowOperation {
   async doAsync() {
-    chrome.windows.create();
+    const currentWindow = await chrome.windows.getCurrent();
+    chrome.windows.create({ state: currentWindow.state });
   }
 }


### PR DESCRIPTION
The operation "open new window" should open a new window with an empty tab, the same size as the previous current window. This is similar to the existing operation "open new tab".

"Open new window" should not duplicate the current tab as a new window. If this is desired, an operation named "duplicate tab in new window" should be added.